### PR TITLE
CR-1190 add circuit-breaker dependency management ; update maven form…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
         <scope>import</scope>
       </dependency>
 
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
+        <version>1.0.4.RELEASE</version>
+      </dependency>
+
       <!-- need separate jaxb deps after java11 removed them -->
       <dependency>
         <groupId>javax.xml.bind</groupId>
@@ -231,7 +237,7 @@
         <plugin>
           <groupId>com.coveo</groupId>
           <artifactId>fmt-maven-plugin</artifactId>
-          <version>2.5.0</version>
+          <version>2.9.1</version>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
…atter to fix array-out-of-bounds bug

It has been agreed to better centralise the common dependency on the circuit-breaker code.
I have also taken the opportunity to upgrade the maven formatter, which has previously plagued us with an intermittent ArrayOutOfBoundsException for a long time.